### PR TITLE
Upgrades JDK to 23 and WireMock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     
-    - name: Set up JDK 17
+    - name: Set up JDK 23
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: '23'
         distribution: 'temurin'
         
     - name: Setup Gradle
@@ -61,25 +61,30 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     
-    - name: Set up JDK 17
+    - name: Set up JDK 23
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: '23'
         distribution: 'temurin'
         
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2
       
+    - name: Debug Dependencies
+      run: |
+        echo "🔍 Checking Jetty dependencies..."
+        ./gradlew dependencies --configuration testRuntimeClasspath | grep -i jetty || true
+        
     - name: Run integration tests
       run: |
         if [ -z "${{ secrets.SHOPIFY_TEST_STORE_DOMAIN }}" ]; then
           echo "⚠️ Skipping integration tests - SHOPIFY_TEST_STORE_DOMAIN secret not configured"
           echo "Set up secrets in repository settings to enable integration tests"
           # Run integration tests anyway to verify they compile and skip properly
-          ./gradlew integrationTest --info || true
+          ./gradlew integrationTest --info --stacktrace || true
         else
           echo "✅ Running integration tests with configured store"
-          ./gradlew integrationTest
+          ./gradlew integrationTest --info --stacktrace
         fi
       env:
         SHOPIFY_TEST_STORE_DOMAIN: ${{ secrets.SHOPIFY_TEST_STORE_DOMAIN }}
@@ -101,10 +106,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     
-    - name: Set up JDK 17
+    - name: Set up JDK 23
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: '23'
         distribution: 'temurin'
         
     - name: Run SpotBugs
@@ -127,10 +132,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     
-    - name: Set up JDK 17
+    - name: Set up JDK 23
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: '23'
         distribution: 'temurin'
         
     - name: Setup Gradle

--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ dependencies {
         exclude group: 'com.vaadin.external.google', module: 'android-json'
     }
     testImplementation 'org.mockito:mockito-junit-jupiter:5.7.0'
-    testImplementation 'com.github.tomakehurst:wiremock-jre8:3.0.1'
+    testImplementation 'org.wiremock:wiremock-jetty12:3.13.1'
     testImplementation 'io.projectreactor:reactor-test'
     testImplementation 'org.awaitility:awaitility:4.2.0'
     testImplementation "org.junit.jupiter:junit-jupiter:${junitVersion}"
@@ -122,6 +122,9 @@ task integrationTest(type: Test) {
     useJUnitPlatform {
         includeTags 'integration'
     }
+    
+    // Enable experimental Byte Buddy for Java compatibility
+    jvmArgs '-Dnet.bytebuddy.experimental=true'
     
     // 환경변수 체크
     doFirst {


### PR DESCRIPTION
Updates the CI workflow to use JDK 23 for builds and tests. Also upgrades WireMock to the jetty12 variant. This addresses potential compatibility issues and leverages newer features. Adds debug output for jetty dependencies and enables Byte Buddy experimental mode for improved Java compatibility during integration tests. Adds stacktrace to integration test output for better debugging.