### PR TITLE
Forces HttpClient 5.5 for WireMock

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,11 @@ configurations.all {
     resolutionStrategy {
         // Force a specific version of snakeyaml
         force 'org.yaml:snakeyaml:2.2'
+        
+        // Force Apache HttpClient 5.5 for WireMock compatibility
+        force 'org.apache.httpcomponents.client5:httpclient5:5.5'
+        force 'org.apache.httpcomponents.core5:httpcore5:5.5'
+        force 'org.apache.httpcomponents.core5:httpcore5-h2:5.5'
     }
 }
 


### PR DESCRIPTION
Forces specific versions of Apache HttpClient 5.5 to ensure compatibility with WireMock. This prevents potential version conflicts and ensures consistent behavior when using WireMock for testing.