### PR TITLE
Fixes WireMock compatibility issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,10 +70,17 @@ jobs:
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2
       
+    - name: Clean Gradle cache
+      run: |
+        rm -rf ~/.gradle/caches/modules-2/files-2.1/org.apache.httpcomponents.client5/
+        rm -rf ~/.gradle/caches/modules-2/files-2.1/org.wiremock/
+        
     - name: Debug Dependencies
       run: |
-        echo "🔍 Checking Jetty dependencies..."
-        ./gradlew dependencies --configuration testRuntimeClasspath | grep -i jetty || true
+        echo "🔍 Checking HttpClient dependencies..."
+        ./gradlew dependencies --configuration testRuntimeClasspath | grep -A 5 -B 5 httpclient5 || true
+        echo "🔍 Checking WireMock dependencies..."
+        ./gradlew dependencies --configuration testRuntimeClasspath | grep -A 5 -B 5 wiremock || true
         
     - name: Run integration tests
       run: |

--- a/build.gradle
+++ b/build.gradle
@@ -39,11 +39,6 @@ configurations.all {
     resolutionStrategy {
         // Force a specific version of snakeyaml
         force 'org.yaml:snakeyaml:2.2'
-        
-        // Force Apache HttpClient 5.4.2 for WireMock compatibility (setProtocolUpgradeEnabled added in 5.4)
-        force 'org.apache.httpcomponents.client5:httpclient5:5.4.2'
-        force 'org.apache.httpcomponents.core5:httpcore5:5.3.2'
-        force 'org.apache.httpcomponents.core5:httpcore5-h2:5.3.2'
     }
 }
 
@@ -102,7 +97,8 @@ dependencies {
         exclude group: 'com.vaadin.external.google', module: 'android-json'
     }
     testImplementation 'org.mockito:mockito-junit-jupiter:5.7.0'
-    testImplementation 'org.wiremock:wiremock-jetty12:3.13.1'
+    // Use WireMock with Jetty 11 instead of Jetty 12 to avoid conflicts
+    testImplementation 'org.wiremock:wiremock:3.9.2'
     testImplementation 'io.projectreactor:reactor-test'
     testImplementation 'org.awaitility:awaitility:4.2.0'
     testImplementation "org.junit.jupiter:junit-jupiter:${junitVersion}"


### PR DESCRIPTION
Updates WireMock to a compatible version and cleans Gradle cache to resolve dependency conflicts, specifically addressing issues related to HttpClient and Jetty versions. Removes unnecessary dependency forcing in `build.gradle`.