### PR TITLE
Avoids Jetty conflicts in tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,8 +97,8 @@ dependencies {
         exclude group: 'com.vaadin.external.google', module: 'android-json'
     }
     testImplementation 'org.mockito:mockito-junit-jupiter:5.7.0'
-    // Use WireMock with Jetty 11 instead of Jetty 12 to avoid conflicts
-    testImplementation 'org.wiremock:wiremock:3.9.2'
+    // Use WireMock standalone version to avoid Jetty conflicts
+    testImplementation 'org.wiremock:wiremock-standalone:3.9.2'
     testImplementation 'io.projectreactor:reactor-test'
     testImplementation 'org.awaitility:awaitility:4.2.0'
     testImplementation "org.junit.jupiter:junit-jupiter:${junitVersion}"

--- a/src/test/java/com/shopify/sdk/config/IntegrationTestConfiguration.java
+++ b/src/test/java/com/shopify/sdk/config/IntegrationTestConfiguration.java
@@ -19,12 +19,8 @@ import org.springframework.context.annotation.Bean;
 @TestConfiguration
 public class IntegrationTestConfiguration {
     
-    @Bean
-    public ObjectMapper objectMapper() {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.registerModule(new JavaTimeModule());
-        return mapper;
-    }
+    // ObjectMapper bean removed to avoid conflicts with ShopifyTestConfiguration
+    // which already provides a @Primary ObjectMapper bean
     
     @Bean
     public ShopifyAuthContext shopifyAuthContext() {


### PR DESCRIPTION
Updates WireMock dependency to the standalone version to prevent conflicts with Jetty.

Removes the ObjectMapper bean from IntegrationTestConfiguration to avoid conflicts with the primary ObjectMapper bean defined in ShopifyTestConfiguration.