### PR TITLE
Enables HTTP for test environments

### DIFF
--- a/src/test/java/com/shopify/sdk/config/MockWebServerTestConfiguration.java
+++ b/src/test/java/com/shopify/sdk/config/MockWebServerTestConfiguration.java
@@ -7,7 +7,11 @@ import com.shopify.sdk.client.ShopifyRestClient;
 import com.shopify.sdk.client.graphql.GraphQLClient;
 import com.shopify.sdk.client.rest.RestClient;
 import com.shopify.sdk.client.rest.RestClientImpl;
+import com.shopify.sdk.exception.ShopifyApiException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.shopify.sdk.model.common.ApiVersion;
+import com.shopify.sdk.model.common.ShopifyConstants;
+import com.shopify.sdk.model.common.ShopifyHeader;
 import com.shopify.sdk.session.SessionManager;
 import com.shopify.sdk.session.SessionStore;
 import com.shopify.sdk.auth.JwtTokenValidator;
@@ -15,7 +19,19 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.http.MediaType;
+import org.springframework.web.util.UriComponentsBuilder;
+import reactor.netty.http.client.HttpClient;
+import reactor.core.publisher.Mono;
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
 import org.mockito.Mockito;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.Map;
 
 /**
  * Test configuration for MockWebServer-based integration tests.
@@ -50,8 +66,41 @@ public class MockWebServerTestConfiguration {
     @Bean
     @Primary
     public HttpClientConfig testHttpClientConfig() {
-        // HttpClientConfig doesn't have setter methods, it uses internal configuration
-        return new HttpClientConfig();
+        // Custom HttpClientConfig for tests that uses HTTP instead of HTTPS
+        return new HttpClientConfig() {
+            @Override
+            public WebClient createAdminApiClient(ShopifyAuthContext context, String shop) {
+                String baseUrl = String.format("http://%s/admin/api/%s", shop, context.getApiVersion().getVersion());
+                return createWebClient(context, baseUrl);
+            }
+            
+            @Override
+            public WebClient createStorefrontApiClient(ShopifyAuthContext context, String shop) {
+                String baseUrl = String.format("http://%s/api/%s/graphql", shop, context.getApiVersion().getVersion());
+                return createWebClient(context, baseUrl);
+            }
+            
+            @Override
+            public WebClient createWebClient(ShopifyAuthContext context, String baseUrl) {
+                HttpClient httpClient = HttpClient.create()
+                    .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, ShopifyConstants.DEFAULT_TIMEOUT_MS)
+                    .responseTimeout(Duration.ofMillis(ShopifyConstants.DEFAULT_TIMEOUT_MS))
+                    .doOnConnected(conn ->
+                        conn.addHandlerLast(new ReadTimeoutHandler(ShopifyConstants.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS))
+                            .addHandlerLast(new WriteTimeoutHandler(ShopifyConstants.DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS)));
+                
+                WebClient.Builder builder = WebClient.builder()
+                    .clientConnector(new ReactorClientHttpConnector(httpClient))
+                    .defaultHeader("User-Agent", ShopifyConstants.DEFAULT_USER_AGENT)
+                    .defaultHeader(ShopifyHeader.API_VERSION.getHeaderName(), context.getApiVersion().getVersion());
+                
+                if (baseUrl != null) {
+                    builder.baseUrl(baseUrl);
+                }
+                
+                return builder.build();
+            }
+        };
     }
     
     @Bean
@@ -75,4 +124,123 @@ public class MockWebServerTestConfiguration {
         SessionManager mock = Mockito.mock(SessionManager.class);
         return mock;
     }
+    
+    @Bean
+    @Primary
+    public RestClient testRestClient(HttpClientConfig httpClientConfig, ObjectMapper objectMapper) {
+        // Custom RestClient for tests that uses HTTP without forcing HTTPS
+        return new RestClient() {
+            @Override
+            public Mono<JsonNode> get(String shop, String accessToken, String endpoint, Map<String, Object> queryParams) {
+                String url = buildTestUrl(shop, endpoint);
+                
+                UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(url);
+                if (queryParams != null) {
+                    queryParams.forEach((key, value) -> {
+                        if (value != null) {
+                            uriBuilder.queryParam(key, value);
+                        }
+                    });
+                }
+                
+                // Create a WebClient with the test URL
+                WebClient webClient = httpClientConfig.createWebClient(testAuthContext(), url);
+                return webClient
+                    .get()
+                    .uri(uriBuilder.build().toUri())
+                    .header("X-Shopify-Access-Token", accessToken)
+                    .header("User-Agent", httpClientConfig.getUserAgent())
+                    .accept(MediaType.APPLICATION_JSON)
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .map(responseBody -> parseResponse(responseBody, objectMapper))
+                    .onErrorMap(this::mapToShopifyApiException);
+            }
+            
+            @Override
+            public Mono<JsonNode> post(String shop, String accessToken, String endpoint, Object body) {
+                String url = buildTestUrl(shop, endpoint);
+                
+                WebClient webClient = httpClientConfig.createWebClient(testAuthContext(), url);
+                return webClient
+                    .post()
+                    .uri(url)
+                    .header("X-Shopify-Access-Token", accessToken)
+                    .header("User-Agent", httpClientConfig.getUserAgent())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .bodyValue(body)
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .map(responseBody -> parseResponse(responseBody, objectMapper))
+                    .onErrorMap(this::mapToShopifyApiException);
+            }
+            
+            @Override
+            public Mono<JsonNode> put(String shop, String accessToken, String endpoint, Object body) {
+                String url = buildTestUrl(shop, endpoint);
+                
+                WebClient webClient = httpClientConfig.createWebClient(testAuthContext(), url);
+                return webClient
+                    .put()
+                    .uri(url)
+                    .header("X-Shopify-Access-Token", accessToken)
+                    .header("User-Agent", httpClientConfig.getUserAgent())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .bodyValue(body)
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .map(responseBody -> parseResponse(responseBody, objectMapper))
+                    .onErrorMap(this::mapToShopifyApiException);
+            }
+            
+            @Override
+            public Mono<JsonNode> delete(String shop, String accessToken, String endpoint) {
+                String url = buildTestUrl(shop, endpoint);
+                
+                WebClient webClient = httpClientConfig.createWebClient(testAuthContext(), url);
+                return webClient
+                    .delete()
+                    .uri(url)
+                    .header("X-Shopify-Access-Token", accessToken)
+                    .header("User-Agent", httpClientConfig.getUserAgent())
+                    .accept(MediaType.APPLICATION_JSON)
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .map(responseBody -> parseResponse(responseBody, objectMapper))
+                    .onErrorMap(this::mapToShopifyApiException);
+            }
+            
+            private String buildTestUrl(String shop, String endpoint) {
+                // For tests, use the shop domain as-is (localhost:port) without forcing HTTPS
+                String baseUrl = String.format("http://%s/admin/api/2024-01", shop);
+                
+                if (!endpoint.startsWith("/")) {
+                    endpoint = "/" + endpoint;
+                }
+                
+                return baseUrl + endpoint;
+            }
+            
+            private JsonNode parseResponse(String responseBody, ObjectMapper objectMapper) {
+                try {
+                    if (responseBody == null || responseBody.trim().isEmpty()) {
+                        return objectMapper.createObjectNode();
+                    }
+                    return objectMapper.readTree(responseBody);
+                } catch (Exception e) {
+                    throw new ShopifyApiException("Failed to parse REST API response", e);
+                }
+            }
+            
+            private Throwable mapToShopifyApiException(Throwable throwable) {
+                if (throwable instanceof ShopifyApiException) {
+                    return throwable;
+                }
+                return new ShopifyApiException("REST API request failed", throwable);
+            }
+        };
+    }
+    
 }

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,14 @@
+# Test-specific Shopify SDK configuration
+shopify.api-key=test-api-key
+shopify.api-secret-key=test-api-secret
+shopify.scopes=read_products,write_products,read_orders,write_orders
+shopify.host-name=localhost:8080
+shopify.api-version=JANUARY_24
+shopify.admin-api-access-token=test-access-token
+
+# Disable SSL for tests
+shopify.use-ssl=false
+
+# Logging configuration for tests
+logging.level.com.shopify.sdk=DEBUG
+logging.level.org.springframework.web.reactive.function.client=DEBUG


### PR DESCRIPTION
Configures the test environment to use HTTP instead of HTTPS.

This change allows integration tests using MockWebServer to communicate over HTTP, simplifying local testing and development.  It achieves this by providing custom `HttpClientConfig` and `RestClient` beans that create `WebClient` instances configured to use HTTP for all API calls, and overrides the base URL to point to the HTTP endpoint of the MockWebServer.

Also includes a test properties file with default configurations, and disables SSL.