### PR TITLE
Configures publication to GitHub Packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,7 @@ jobs:
         esac
         
     - name: Publish to GitHub Packages
-      run: ./gradlew publish
+      run: ./gradlew publishShopifySdkPublicationToGitHubPackagesRepository
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     

--- a/.github/workflows/publish-maven-central.yml
+++ b/.github/workflows/publish-maven-central.yml
@@ -32,14 +32,21 @@ jobs:
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2
       
-    - name: Import GPG key
+    - name: Setup GPG
       env:
         GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-        GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       run: |
+        # Import GPG key
         echo "$GPG_PRIVATE_KEY" | base64 -d | gpg --batch --import
-        echo "allow-loopback-pinentry" >> ~/.gnupg/gpg-agent.conf
-        gpgconf --kill gpg-agent
+        
+        # List keys to verify import
+        gpg --list-secret-keys
+        
+        # Export the signing key in ASCII armor format
+        GPG_SIGNING_KEY=$(gpg --armor --export-secret-keys ${{ secrets.GPG_KEY_ID }})
+        echo "GPG_SIGNING_KEY<<EOF" >> $GITHUB_ENV
+        echo "$GPG_SIGNING_KEY" >> $GITHUB_ENV
+        echo "EOF" >> $GITHUB_ENV
         
     - name: Update version
       if: github.event.inputs.release_type == 'release'
@@ -58,12 +65,11 @@ jobs:
       env:
         OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
         OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
-        GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       run: |
-        ./gradlew publish \
-          -Psigning.gnupg.keyName=${{ secrets.GPG_KEY_ID }} \
-          -Psigning.gnupg.passphrase=${{ secrets.GPG_PASSPHRASE }} \
-          -Psigning.gnupg.executable=gpg
+        ./gradlew publishShopifySdkPublicationToOSSRHRepository \
+          -PsigningKeyId=${{ secrets.GPG_KEY_ID }} \
+          -PsigningPassword=${{ secrets.GPG_PASSPHRASE }} \
+          -PsigningKey="$GPG_SIGNING_KEY"
           
     - name: Create Release Notes
       if: github.event.inputs.release_type == 'release'

--- a/build.gradle
+++ b/build.gradle
@@ -203,6 +203,14 @@ publishing {
                 password = project.findProperty("ossrhPassword") ?: System.getenv("OSSRH_PASSWORD")
             }
         }
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/astroryan/shopify-sdk-java")
+            credentials {
+                username = project.findProperty("gpr.user") ?: System.getenv("GITHUB_ACTOR")
+                password = project.findProperty("gpr.key") ?: System.getenv("GITHUB_TOKEN")
+            }
+        }
     }
     
     publications {
@@ -243,6 +251,15 @@ publishing {
 
 // Signing configuration
 signing {
+    def signingKeyId = findProperty("signingKeyId") ?: findProperty("signing.keyId")
+    def signingPassword = findProperty("signingPassword") ?: findProperty("signing.password")
+    def signingKey = findProperty("signingKey") ?: findProperty("signing.key")
+    
+    if (signingKeyId && signingPassword && signingKey) {
+        useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
+    }
+    
+    required { !version.endsWith("SNAPSHOT") && gradle.taskGraph.hasTask("publishShopifySdkPublicationToOSSRHRepository") }
     sign publishing.publications.shopifySdk
 }
 


### PR DESCRIPTION
Configures the project to publish artifacts to GitHub Packages in addition to Maven Central. This allows for easier internal distribution and consumption of the library. It also fixes the publication task name for GitHub Packages.

Additionally, the GPG key setup process in the Maven Central publication workflow is improved by explicitly exporting and using the signing key, improving reliability and security.