### PR TITLE
Removes snapshot version check for publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -259,7 +259,7 @@ signing {
         useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
     }
     
-    required { !version.endsWith("SNAPSHOT") && gradle.taskGraph.hasTask("publishShopifySdkPublicationToOSSRHRepository") }
+    required { gradle.taskGraph.hasTask("publishShopifySdkPublicationToOSSRHRepository") }
     sign publishing.publications.shopifySdk
 }
 


### PR DESCRIPTION
Removes the check that prevents publishing when the version ends with "SNAPSHOT".

This allows snapshot versions to be published to the OSSRH repository, which is useful for testing and development purposes.