### PR TITLE
Restricts signing to Maven Central publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -249,18 +249,19 @@ publishing {
     }
 }
 
-// Signing configuration
-signing {
-    def signingKeyId = findProperty("signingKeyId") ?: findProperty("signing.keyId")
-    def signingPassword = findProperty("signingPassword") ?: findProperty("signing.password")
-    def signingKey = findProperty("signingKey") ?: findProperty("signing.key")
-    
-    if (signingKeyId && signingPassword && signingKey) {
-        useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
+// Signing configuration - only for Maven Central
+if (project.hasProperty("signingKeyId") || project.hasProperty("signing.keyId")) {
+    signing {
+        def signingKeyId = findProperty("signingKeyId") ?: findProperty("signing.keyId")
+        def signingPassword = findProperty("signingPassword") ?: findProperty("signing.password")
+        def signingKey = findProperty("signingKey") ?: findProperty("signing.key")
+        
+        if (signingKeyId && signingPassword && signingKey) {
+            useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
+        }
+        
+        sign publishing.publications.shopifySdk
     }
-    
-    required { gradle.taskGraph.hasTask("publishShopifySdkPublicationToOSSRHRepository") }
-    sign publishing.publications.shopifySdk
 }
 
 // Task to display publish info


### PR DESCRIPTION
Ensures signing configuration is only applied when publishing to Maven Central.

This prevents errors when signing is not required for other publishing tasks.