### PR TITLE
Updates Maven Central repository URLs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -195,9 +195,9 @@ publishing {
     repositories {
         maven {
             name = "OSSRH"
-            def releasesRepoUrl = "https://central.sonatype.com/api/v1/publisher/upload"
-            def snapshotsRepoUrl = "https://central.sonatype.com/api/v1/publisher/upload"
-            url = releasesRepoUrl
+            def releasesRepoUrl = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+            def snapshotsRepoUrl = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
+            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
             credentials {
                 username = project.findProperty("mavenCentralUsername") ?: System.getenv("MAVEN_CENTRAL_USERNAME")
                 password = project.findProperty("mavenCentralPassword") ?: System.getenv("MAVEN_CENTRAL_PASSWORD")


### PR DESCRIPTION
Updates the Maven Central repository URLs to the new Sonatype OSSRH URLs.

The previous URLs are deprecated and no longer function for publishing. This change ensures that the publishing process continues to work.