### PR TITLE
Adds OSSRH authentication test and signing config

### DIFF
--- a/.github/workflows/publish-maven-central.yml
+++ b/.github/workflows/publish-maven-central.yml
@@ -74,6 +74,22 @@ jobs:
         echo "Maven Central username length: ${#MAVEN_CENTRAL_USERNAME}"
         echo "GPG Key ID: ${{ secrets.GPG_KEY_ID }}"
         
+    - name: Test OSSRH authentication
+      env:
+        MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+        MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+      run: |
+        echo "Testing OSSRH authentication..."
+        AUTH=$(echo -n "${MAVEN_CENTRAL_USERNAME}:${MAVEN_CENTRAL_PASSWORD}" | base64)
+        RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" \
+          -H "Authorization: Basic $AUTH" \
+          https://s01.oss.sonatype.org/service/local/authentication/login)
+        echo "OSSRH auth response: $RESPONSE"
+        if [ "$RESPONSE" != "200" ]; then
+          echo "⚠️ OSSRH authentication failed. Please check your credentials."
+          echo "Make sure you're using Maven Central User Token, not regular username/password."
+        fi
+        
     - name: Build and publish to Maven Central
       env:
         MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}

--- a/build.gradle
+++ b/build.gradle
@@ -252,7 +252,7 @@ publishing {
 // Signing configuration
 signing {
     def signingKeyId = findProperty("signingKeyId")
-    def signingPassword = findProperty("signingPassword")
+    def signingPassword = findProperty("signingPassword")  
     def signingKey = findProperty("signingKey")
     
     if (signingKeyId && signingPassword && signingKey) {
@@ -262,11 +262,17 @@ signing {
     sign publishing.publications.shopifySdk
 }
 
-// Disable signing for GitHub Packages
+// Configure signing tasks
 tasks.withType(Sign) {
     onlyIf {
+        // Only sign when publishing to Maven Central
         gradle.taskGraph.hasTask("publishShopifySdkPublicationToOSSRHRepository")
     }
+}
+
+// Make publish task depend on signing
+tasks.named("publishShopifySdkPublicationToOSSRHRepository") {
+    dependsOn "signShopifySdkPublication"
 }
 
 // Task to display publish info


### PR DESCRIPTION
Adds a test to verify OSSRH authentication using provided credentials before attempting to publish.

Configures signing tasks to only sign when publishing to Maven Central and ensures the publish task depends on the signing task. This prevents signing when publishing to GitHub Packages.