### PR TITLE
Migrates to Maven Central Portal API

### DIFF
--- a/.github/workflows/publish-maven-central.yml
+++ b/.github/workflows/publish-maven-central.yml
@@ -95,7 +95,7 @@ jobs:
         MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
         MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
       run: |
-        ./gradlew publishShopifySdkPublicationToOSSRHRepository \
+        ./gradlew publishAllPublicationsToMavenCentralPortal \
           -PmavenCentralUsername="${MAVEN_CENTRAL_USERNAME}" \
           -PmavenCentralPassword="${MAVEN_CENTRAL_PASSWORD}" \
           -PsigningKeyId=${{ secrets.GPG_KEY_ID }} \

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ plugins {
     id 'jacoco'
     id 'maven-publish'
     id 'signing'
+    id 'com.gradleup.nmcp' version '0.0.8'
 }
 
 group = 'io.github.astroryan'
@@ -275,10 +276,19 @@ tasks.named("publishShopifySdkPublicationToOSSRHRepository") {
     dependsOn "signShopifySdkPublication"
 }
 
+// Configure nmcp plugin for Maven Central Portal
+nmcp {
+    publishAllPublications {
+        username = project.findProperty("mavenCentralUsername") ?: System.getenv("MAVEN_CENTRAL_USERNAME")
+        password = project.findProperty("mavenCentralPassword") ?: System.getenv("MAVEN_CENTRAL_PASSWORD")
+        publicationType = "USER_MANAGED" // or "AUTOMATIC"
+    }
+}
+
 // Task to display publish info
 task publishInfo {
     doLast {
         println "Publishing ${project.group}:${project.name}:${project.version}"
-        println "To Maven Central via OSSRH"
+        println "To Maven Central via Portal API"
     }
 }


### PR DESCRIPTION
Updates the publishing process to utilize the Maven Central Portal API instead of OSSRH.

This change simplifies the publishing workflow by leveraging the new Maven Central Portal API, offering better integration and management of artifacts.