### PR TITLE
Migrates to vanniktech maven publish plugin

### DIFF
--- a/.github/workflows/publish-maven-central.yml
+++ b/.github/workflows/publish-maven-central.yml
@@ -74,33 +74,32 @@ jobs:
         echo "Maven Central username length: ${#MAVEN_CENTRAL_USERNAME}"
         echo "GPG Key ID: ${{ secrets.GPG_KEY_ID }}"
         
-    - name: Test OSSRH authentication
+    - name: Test Maven Central Portal authentication
       env:
         MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
         MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
       run: |
-        echo "Testing OSSRH authentication..."
-        AUTH=$(echo -n "${MAVEN_CENTRAL_USERNAME}:${MAVEN_CENTRAL_PASSWORD}" | base64)
+        echo "Testing Maven Central Portal authentication..."
         RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" \
-          -H "Authorization: Basic $AUTH" \
-          https://s01.oss.sonatype.org/service/local/authentication/login)
-        echo "OSSRH auth response: $RESPONSE"
+          -X GET \
+          -u "${MAVEN_CENTRAL_USERNAME}:${MAVEN_CENTRAL_PASSWORD}" \
+          https://central.sonatype.com/api/v1/publisher/deployments)
+        echo "Maven Central Portal auth response: $RESPONSE"
         if [ "$RESPONSE" != "200" ]; then
-          echo "⚠️ OSSRH authentication failed. Please check your credentials."
-          echo "Make sure you're using Maven Central User Token, not regular username/password."
+          echo "⚠️ Maven Central Portal authentication failed. Please check your credentials."
+          echo "Make sure you're using User Token credentials from central.sonatype.com"
         fi
         
     - name: Build and publish to Maven Central
       env:
-        MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-        MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+        ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+        ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+        ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ env.GPG_SIGNING_KEY }}
+        ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.GPG_KEY_ID }}
+        ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSPHRASE }}
       run: |
-        ./gradlew publishAllPublicationsToMavenCentralPortal \
-          -PmavenCentralUsername="${MAVEN_CENTRAL_USERNAME}" \
-          -PmavenCentralPassword="${MAVEN_CENTRAL_PASSWORD}" \
-          -PsigningKeyId=${{ secrets.GPG_KEY_ID }} \
-          -PsigningPassword=${{ secrets.GPG_PASSPHRASE }} \
-          -PsigningKey="$GPG_SIGNING_KEY" \
+        ./gradlew publishAllPublicationsToMavenCentralRepository \
+          --no-configuration-cache \
           --info --stacktrace
           
     - name: Create Release Notes
@@ -131,5 +130,7 @@ jobs:
           echo "📦 [Maven Central](https://central.sonatype.com/artifact/io.github.astroryan/shopify-spring-sdk/${{ github.event.inputs.version }})" >> $GITHUB_STEP_SUMMARY
         else
           echo "✅ Published Snapshot: v${{ github.event.inputs.version }}-SNAPSHOT" >> $GITHUB_STEP_SUMMARY
-          echo "📦 [OSSRH Snapshots](https://s01.oss.sonatype.org/content/repositories/snapshots/io/github/astroryan/shopify-spring-sdk/)" >> $GITHUB_STEP_SUMMARY
+          echo "📦 [Maven Central Portal](https://central.sonatype.com/namespace/io.github.astroryan)" >> $GITHUB_STEP_SUMMARY
         fi
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "⏳ Note: Artifacts may take up to 30 minutes to appear in Maven Central" >> $GITHUB_STEP_SUMMARY

--- a/build.gradle
+++ b/build.gradle
@@ -4,9 +4,8 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.4'
     id 'java-library'
     id 'jacoco'
-    id 'maven-publish'
+    id 'com.vanniktech.maven.publish' version '0.28.0'
     id 'signing'
-    id 'com.gradleup.nmcp' version '0.0.8'
 }
 
 group = 'io.github.astroryan'
@@ -191,20 +190,47 @@ sourceSets {
     }
 }
 
-// Publishing configuration
+// Publishing configuration for vanniktech plugin
+import com.vanniktech.maven.publish.SonatypeHost
+
+mavenPublishing {
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+    signAllPublications()
+    
+    coordinates("io.github.astroryan", "shopify-spring-sdk", version)
+    
+    pom {
+        name = 'Shopify Spring SDK'
+        description = 'A comprehensive Spring Boot SDK for Shopify Admin GraphQL API'
+        url = 'https://github.com/astroryan/shopify-sdk-java'
+        
+        licenses {
+            license {
+                name = 'The Apache License, Version 2.0'
+                url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+            }
+        }
+        
+        developers {
+            developer {
+                id = 'astroryan'
+                name = 'Ryan Kim'
+                email = 'ryan@example.com'
+            }
+        }
+        
+        scm {
+            connection = 'scm:git:git://github.com/astroryan/shopify-sdk-java.git'
+            developerConnection = 'scm:git:ssh://github.com:astroryan/shopify-sdk-java.git'
+            url = 'https://github.com/astroryan/shopify-sdk-java'
+        }
+    }
+}
+
+// GitHub Packages publishing configuration
 publishing {
     repositories {
         maven {
-            name = "OSSRH"
-            def releasesRepoUrl = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
-            def snapshotsRepoUrl = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
-            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
-            credentials {
-                username = project.findProperty("mavenCentralUsername") ?: System.getenv("MAVEN_CENTRAL_USERNAME")
-                password = project.findProperty("mavenCentralPassword") ?: System.getenv("MAVEN_CENTRAL_PASSWORD")
-            }
-        }
-         maven {
             name = "GitHubPackages"
             url = uri("https://maven.pkg.github.com/astroryan/shopify-sdk-java")
             credentials {
@@ -215,73 +241,35 @@ publishing {
     }
     
     publications {
-        shopifySdk(MavenPublication) {
+        githubPackages(MavenPublication) {
             from components.java
-            
             artifactId = 'shopify-spring-sdk'
-            
-            pom {
-                name = 'Shopify Spring SDK'
-                description = 'A comprehensive Spring Boot SDK for Shopify Admin GraphQL API'
-                url = 'https://github.com/astroryan/shopify-sdk-java'
-                
-                licenses {
-                    license {
-                        name = 'The Apache License, Version 2.0'
-                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                    }
-                }
-                
-                developers {
-                    developer {
-                        id = 'astroryan'
-                        name = 'Ryan Kim'
-                        email = 'ryan@example.com'
-                    }
-                }
-                
-                scm {
-                    connection = 'scm:git:git://github.com/astroryan/shopify-sdk-java.git'
-                    developerConnection = 'scm:git:ssh://github.com:astroryan/shopify-sdk-java.git'
-                    url = 'https://github.com/astroryan/shopify-sdk-java'
-                }
-            }
         }
     }
 }
 
-// Signing configuration
-signing {
-    def signingKeyId = findProperty("signingKeyId")
-    def signingPassword = findProperty("signingPassword")  
-    def signingKey = findProperty("signingKey")
-    
-    if (signingKeyId && signingPassword && signingKey) {
-        useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
-    }
-    
-    sign publishing.publications.shopifySdk
-}
-
-// Configure signing tasks
+// Configure signing tasks for GitHub Packages only
 tasks.withType(Sign) {
     onlyIf {
-        // Only sign when publishing to Maven Central
-        gradle.taskGraph.hasTask("publishShopifySdkPublicationToOSSRHRepository")
+        // Only sign when publishing to GitHub Packages if credentials are available
+        gradle.taskGraph.hasTask("publishGithubPackagesPublicationToGitHubPackagesRepository") &&
+        project.hasProperty("signingKeyId") &&
+        project.hasProperty("signingPassword") &&
+        project.hasProperty("signingKey")
     }
 }
 
-// Make publish task depend on signing
-tasks.named("publishShopifySdkPublicationToOSSRHRepository") {
-    dependsOn "signShopifySdkPublication"
-}
-
-// Configure nmcp plugin for Maven Central Portal
-nmcp {
-    publishAllPublications {
-        username = project.findProperty("mavenCentralUsername") ?: System.getenv("MAVEN_CENTRAL_USERNAME")
-        password = project.findProperty("mavenCentralPassword") ?: System.getenv("MAVEN_CENTRAL_PASSWORD")
-        publicationType = "USER_MANAGED" // or "AUTOMATIC"
+// Optional: Sign GitHub Packages publication if credentials are available
+if (project.hasProperty("signingKeyId") && 
+    project.hasProperty("signingPassword") && 
+    project.hasProperty("signingKey")) {
+    signing {
+        useInMemoryPgpKeys(
+            project.property("signingKeyId"),
+            project.property("signingKey"),
+            project.property("signingPassword")
+        )
+        sign publishing.publications.githubPackages
     }
 }
 


### PR DESCRIPTION
Migrates from the gradle-maven-publish-plugin to the vanniktech maven publish plugin for publishing to Maven Central.

This change simplifies the publishing configuration, leverages the Sonatype Central Portal, and improves the overall publishing process.

- Updates the workflow to use the new plugin and associated environment variables.
- Removes OSSRH references and updates documentation links to Maven Central Portal.