### PR TITLE
Improves Javadoc generation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
     id 'java'
     id 'org.springframework.boot' version '3.3.9'
@@ -173,13 +175,30 @@ bootJar {
 
 // Configure javadoc to work with Lombok
 javadoc {
+    // Disable strict checking for javadoc
     options.addStringOption('Xdoclint:none', '-quiet')
+    
     if(JavaVersion.current().isJava9Compatible()) {
         options.addBooleanOption('html5', true)
     }
+    
+    // Exclude problematic files
     exclude '**/package-info.java'
-    classpath = configurations.compileClasspath
+    
+    // Include compiled classes in classpath for Lombok
+    classpath = sourceSets.main.compileClasspath + sourceSets.main.output
+    
+    // Additional options for better compatibility
+    options.encoding = 'UTF-8'
+    options.author = true
+    options.use = true
+    
+    // Skip on error to prevent build failure
+    failOnError = false
 }
+
+// Ensure javadoc runs after classes are compiled (for Lombok)
+javadoc.dependsOn compileJava
 
 // Test fixture resources
 sourceSets {
@@ -191,8 +210,6 @@ sourceSets {
 }
 
 // Publishing configuration for vanniktech plugin
-import com.vanniktech.maven.publish.SonatypeHost
-
 mavenPublishing {
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
     signAllPublications()


### PR DESCRIPTION
Enhances Javadoc generation process by disabling strict checking, excluding problematic files, including compiled classes in the classpath and adding options for better compatibility with Lombok. Also ensures Javadoc runs after compilation and skip on error to avoid build failures.