### PR TITLE
Configures publishing to Maven Central

### DIFF
--- a/.github/workflows/auto-publish-release.yml
+++ b/.github/workflows/auto-publish-release.yml
@@ -11,6 +11,9 @@ jobs:
   publish-release:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Needed to push tags and create releases
+      pull-requests: read
     
     steps:
     - uses: actions/checkout@v4

--- a/build.gradle
+++ b/build.gradle
@@ -393,7 +393,12 @@ sourceSets {
 
 // Publishing configuration for vanniktech plugin
 mavenPublishing {
-    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+    // Use different hosts based on version type
+    if (version.toString().endsWith("-SNAPSHOT")) {
+        publishToMavenCentral(SonatypeHost.S01)  // Sonatype OSS for snapshots
+    } else {
+        publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)  // Central Portal for releases
+    }
     signAllPublications()
     
     coordinates("io.github.astroryan", "shopify-spring-sdk", version)


### PR DESCRIPTION
Configures the publishing process to use different Sonatype hosts based on whether the version is a snapshot or a release. This allows for proper deployment to the appropriate Maven repository. It also grants write permissions for pushing tags and creating releases, and read permissions for pull requests to the auto-publish-release workflow.